### PR TITLE
ci: optimize docs workflow and pre-commit configuration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build-and-deploy:
@@ -23,16 +23,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install project for doc generation
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
 
       - name: Download validation reports
         if: github.event_name == 'workflow_run'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@
 
 default_install_hook_types: [pre-commit, commit-msg]
 default_stages: [pre-commit]
+fail_fast: true
 
 repos:
   # =============================================================================
@@ -12,6 +13,8 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main, --branch, master]
       # Whitespace & Line Endings
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -35,8 +38,6 @@ repos:
       - id: check-case-conflict
       - id: check-added-large-files
         args: [--maxkb=1000]
-      - id: no-commit-to-branch
-        args: [--branch, main, --branch, master]
 
       # Security - Private Keys
       - id: detect-private-key


### PR DESCRIPTION
## Summary
- Enable cancel-in-progress for docs workflow to prevent duplicate runs
- Add fail_fast to pre-commit configuration for faster feedback
- Move no-commit-to-branch hook earlier for early validation
- Remove unnecessary Python setup steps from docs workflow