### PR TITLE
Fix Schemathesis test case generation

### DIFF
--- a/scripts/utils/schemathesis_runner.py
+++ b/scripts/utils/schemathesis_runner.py
@@ -255,16 +255,13 @@ class SchemathesisRunner:
         max_cases: int = 10,
     ) -> Generator[Case]:
         """Generate test cases for an operation using Hypothesis."""
-        count = 0
         try:
-            # In schemathesis 4.x, we need to use the test method
-            # which generates cases directly
+            # In schemathesis 4.x, we use as_strategy() to get a strategy
+            # and call .example() multiple times to generate different cases
             test_func = operation.as_strategy()
-            for case in test_func.example():
-                if count >= max_cases:
-                    break
+            for _ in range(max_cases):
+                case = test_func.example()
                 yield case
-                count += 1
         except Exception as e:
             console.print(f"[yellow]Failed to generate cases for {operation.path}: {e}[/yellow]")
 


### PR DESCRIPTION
## Problem
Test case generation was failing with "'Case' object is not iterable" error, causing all operations to show 0 examples tested.

## Root Cause
In the `_generate_test_cases` method, the code was trying to iterate over the result of `.example()`:
```python
for case in test_func.example():
    yield case
```

However, `.example()` returns a single Case object, not an iterable of cases.

## Solution
Call `.example()` multiple times in a loop to generate different test cases:
```python
for _ in range(max_cases):
    case = test_func.example()
    yield case
```

## Expected Outcome
- Operations should now be tested with multiple generated test cases
- Examples tested should be > 0 for each operation
- Discrepancies should be detected if they exist in the API