### PR TITLE
Fix Schemathesis results tracking in summary

### DIFF
--- a/scripts/utils/schemathesis_runner.py
+++ b/scripts/utils/schemathesis_runner.py
@@ -380,6 +380,8 @@ class SchemathesisRunner:
                     console.print(f"[yellow]Error checking operation: {e}[/yellow]")
                     continue
 
+        # Update self.results for get_summary()
+        self.results.extend(results)
         return results
 
     def _matches_crud_operation(


### PR DESCRIPTION
Problem: run_stateful_tests was not updating self.results, causing get_summary to show 0 operations tested.

Solution: Update self.results with extend before returning results.

This matches the pattern used in run_tests method.