### PR TITLE
Fix Schemathesis 4.x FailureGroup exception handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ f5xc-reconcile = "scripts.reconcile:main"
 f5xc-release = "scripts.release:main"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 100
 
 [tool.ruff.lint]
@@ -87,7 +87,7 @@ addopts = "-v --tb=short"
 asyncio_mode = "auto"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true

--- a/scripts/utils/schemathesis_runner.py
+++ b/scripts/utils/schemathesis_runner.py
@@ -231,8 +231,24 @@ class SchemathesisRunner:
                     try:
                         # Schemathesis 4.x validation
                         case.validate_response(response)
+                    except BaseExceptionGroup as eg:
+                        # Schemathesis 4.x raises FailureGroup (exception group) for validation failures
+                        # Extract individual validation failures and create discrepancies
+                        for validation_error in eg.exceptions:
+                            discrepancy = Discrepancy(
+                                path=case.path,
+                                property_name="response_schema",
+                                constraint_type="schema_validation",
+                                discrepancy_type=DiscrepancyType.CONSTRAINT_MISMATCH,
+                                spec_value="Valid per OpenAPI schema",
+                                api_behavior=str(validation_error),
+                                test_values=[self._case_to_dict(case)],
+                                recommendation=f"Update schema or fix API response: {validation_error}",
+                            )
+                            result.discrepancies.append(discrepancy)
+                        result.status = TestStatus.FAILED
                     except Exception as validation_error:
-                        # Schema validation failed - this is a discrepancy
+                        # Fallback for non-group exceptions
                         discrepancy = Discrepancy(
                             path=case.path,
                             property_name="response_schema",


### PR DESCRIPTION
## Problem
PR #19 added schema validation using `case.validate_response()`, but Schemathesis 4.x raises `FailureGroup` (exception group) for validation failures. The generic `except Exception` handler didn't catch this, causing the validation pipeline to crash.

## Solution
- Catch `BaseExceptionGroup` to properly handle Schemathesis 4.x `FailureGroup` exceptions
- Extract individual validation failures from the exception group
- Create separate `Discrepancy` objects for each validation failure
- Keep fallback `Exception` handler for non-group exceptions
- Update ruff and mypy target versions to Python 3.11 to match GitHub Actions runtime

## Testing
- All pre-commit hooks pass (ruff, mypy, bandit, etc.)
- Code properly handles exception groups in Python 3.11+
- Validation should now detect API discrepancies instead of crashing

## Impact
This fixes the validation pipeline crash and should finally detect the discrepancies that were found in local testing but not showing up in CI/CD.

Closes #19 regression