### PR TITLE
Fix markdown table rendering with multiline content

### DIFF
--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from rich.console import Console
@@ -39,7 +39,7 @@ def generate_modifications_page(report: dict | None, output_path: Path) -> None:
     ]
 
     # Add generation timestamp
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
     lines.extend(
         [
             f"*Last updated: {now}*",
@@ -167,7 +167,9 @@ def _format_value(value) -> str:
         return (
             f"`{json.dumps(value)[:50]}...`" if len(str(value)) > 50 else f"`{json.dumps(value)}`"
         )
-    return f"`{value}`"
+    # Replace newlines with HTML line breaks for markdown tables
+    str_value = str(value).replace("\n", "<br>")
+    return f"`{str_value}`"
 
 
 def _get_type_badge(dtype: str) -> str:


### PR DESCRIPTION
## Problem
The validation report discrepancies contain multiline text in the `api_behavior` field, which breaks markdown table rendering when newlines are included directly in table cells.

Example broken content:
```
Undocumented Content-Type

Received: text/plain
Documented: application/json
```

This causes the markdown tables to render incorrectly on the GitHub Pages site.

## Solution
Replace newlines with HTML `<br>` tags in the `_format_value()` function:
- Changes `"\n"` to `"<br>"` for all string values
- Works with Material for MkDocs which already has `md_in_html` extension enabled
- Preserves multiline content visibility while keeping tables valid

## Testing
- Generated docs with latest validation report
- Verified table cells now contain `<br>` tags instead of literal newlines
- Confirmed markdown is valid and will render properly

## Impact
Fixes the table rendering issue at:
https://robinmordasiewicz.github.io/f5xc-api-fixed/#apiconfignamespacesnamespaceapi_discoverysname

Users will now be able to see the discrepancy details properly formatted in tables.