### PR TITLE
Fix HTML escaping in markdown table cells

### DIFF
--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -169,6 +169,9 @@ def _format_value(value) -> str:
         )
     # Replace newlines with HTML line breaks for markdown tables
     str_value = str(value).replace("\n", "<br>")
+    # Don't wrap in backticks if it contains HTML (backticks escape HTML entities)
+    if "<br>" in str_value:
+        return str_value
     return f"`{str_value}`"
 
 


### PR DESCRIPTION
## Problem
PR #22 fixed multiline content in markdown tables by replacing newlines with `<br>` tags, but the tags were being HTML-escaped to `&lt;br&gt;` instead of rendering as line breaks.

## Root Cause
The `_format_value()` function was wrapping all values in backticks for code formatting:
```python
return f"`{str_value}`"
```

Backticks in markdown treat content as literal text and escape all HTML entities, turning `<br>` into `&lt;br&gt;`.

## Solution
Conditionally remove backticks when content contains HTML tags:
```python
# Don't wrap in backticks if it contains HTML (backticks escape HTML entities)
if "<br>" in str_value:
    return str_value  # No backticks, HTML will render properly
return f"`{str_value}`"  # Backticks for non-HTML content
```

This preserves:
- ✅ Line breaks in multiline discrepancy messages
- ✅ Code formatting for simple values
- ✅ Proper HTML rendering in MkDocs tables

## Testing
- Generated docs locally with updated code
- Verified markdown contains unescaped `<br>` tags
- Example: `Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json`

## Related Issues
- Fixes rendering issue at: https://robinmordasiewicz.github.io/f5xc-api-fixed/#apiconfignamespacesnamespaceapi_discoverysname
- Completes the fix started in PR #22

🤖 Generated with Claude Code