### PR TITLE
fix: use REPO_ADMIN_TOKEN in update-docs job

### DIFF
--- a/.github/workflows/validate-and-release.yml
+++ b/.github/workflows/validate-and-release.yml
@@ -414,6 +414,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.REPO_ADMIN_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -440,7 +442,7 @@ jobs:
 
       - name: Commit and PR if changed
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- The `update-docs` job in `validate-and-release.yml` was creating PRs using `GITHUB_TOKEN`, which doesn't trigger other workflows due to GitHub's anti-recursion protection
- The "Check linked issues" required check never starts, blocking auto-merge
- Switch to `REPO_ADMIN_TOKEN` for checkout and PR operations so downstream workflows trigger correctly

Closes #48

## Test plan
- [ ] Verify the `update-docs` job uses `REPO_ADMIN_TOKEN` for checkout
- [ ] Verify the `GH_TOKEN` env var in the commit-and-PR step uses `REPO_ADMIN_TOKEN`
- [ ] Confirm "Check linked issues" workflow triggers on PRs created by this job

🤖 Generated with [Claude Code](https://claude.com/claude-code)