### PR TITLE
fix: replace unclosed <br> tags with self-closing <br/> for MDX compatibility

### DIFF
--- a/docs/01-validation-report.mdx
+++ b/docs/01-validation-report.mdx
@@ -23,166 +23,166 @@ This project validates F5 XC OpenAPI specifications against the live API, identi
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
 ### /api/config/namespaces/{namespace}/api_discoverys/{name}
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
 ### /api/config/namespaces/{namespace}/app_firewalls/{name}
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
 ### /api/config/namespaces/{namespace}/code_base_integrations/{name}
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
 ### /api/config/namespaces/{namespace}/data_types/{name}
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
 ### /api/config/namespaces/{namespace}/sensitive_data_policys/{name}
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
 ### /api/web/namespaces/{namespace}/api_groups/{name}
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
-| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br><br>Received: text/plain<br>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
+| `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
 ## Fix Strategies
 


### PR DESCRIPTION
## Summary
- Replaced all 130 unclosed `<br>` tags with self-closing `<br/>` in `docs/01-validation-report.mdx`
- Fixes MDX build failure caused by unclosed HTML tags, which MDX (JSX-based) requires to be self-closing

Closes #67

## Test plan
- [ ] Verify the Astro/Starlight MDX build completes without `<br>` tag errors
- [ ] Confirm the validation report table renders correctly with line breaks intact
- [ ] Check that no other unclosed HTML tags remain in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)