### PR TITLE
fix: escape curly braces in MDX headings to prevent JSX evaluation

### DIFF
--- a/docs/01-validation-report.mdx
+++ b/docs/01-validation-report.mdx
@@ -19,7 +19,7 @@ This project validates F5 XC OpenAPI specifications against the live API, identi
 
 ## Modifications by File
 
-### /api/config/namespaces/{namespace}/api_definitions/{name}
+### `/api/config/namespaces/{namespace}/api_definitions/{name}`
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
@@ -44,7 +44,7 @@ This project validates F5 XC OpenAPI specifications against the live API, identi
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
-### /api/config/namespaces/{namespace}/api_discoverys/{name}
+### `/api/config/namespaces/{namespace}/api_discoverys/{name}`
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
@@ -69,7 +69,7 @@ This project validates F5 XC OpenAPI specifications against the live API, identi
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
-### /api/config/namespaces/{namespace}/app_firewalls/{name}
+### `/api/config/namespaces/{namespace}/app_firewalls/{name}`
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
@@ -94,7 +94,7 @@ This project validates F5 XC OpenAPI specifications against the live API, identi
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
-### /api/config/namespaces/{namespace}/code_base_integrations/{name}
+### `/api/config/namespaces/{namespace}/code_base_integrations/{name}`
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
@@ -119,7 +119,7 @@ This project validates F5 XC OpenAPI specifications against the live API, identi
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
-### /api/config/namespaces/{namespace}/data_types/{name}
+### `/api/config/namespaces/{namespace}/data_types/{name}`
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
@@ -144,7 +144,7 @@ This project validates F5 XC OpenAPI specifications against the live API, identi
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
-### /api/config/namespaces/{namespace}/sensitive_data_policys/{name}
+### `/api/config/namespaces/{namespace}/sensitive_data_policys/{name}`
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|
@@ -169,7 +169,7 @@ This project validates F5 XC OpenAPI specifications against the live API, identi
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 | `response_schema` | `schema_validation` | **Mismatch** | `Valid per OpenAPI schema` | Undocumented Content-Type<br/><br/>Received: text/plain<br/>Documented: application/json |
 
-### /api/web/namespaces/{namespace}/api_groups/{name}
+### `/api/web/namespaces/{namespace}/api_groups/{name}`
 
 | Property | Constraint | Type | Spec Value | API Behavior |
 |----------|------------|------|------------|--------------|


### PR DESCRIPTION
## Summary
- Wrap 7 API path headings in backticks to prevent MDX from interpreting `{namespace}` and `{name}` as JSX expressions
- Resolves runtime error: `namespace is not defined`

Closes #69

## Test plan
- [ ] Verify Pages deploy succeeds after merge
- [ ] Confirm headings render as inline code in the built site

🤖 Generated with [Claude Code](https://claude.com/claude-code)